### PR TITLE
Adding initial project command and a few other cleanup items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,43 @@
 chg-cli
 =======
 
-
-
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/chg-cli.svg)](https://npmjs.org/package/chg-cli)
 [![Downloads/week](https://img.shields.io/npm/dw/chg-cli.svg)](https://npmjs.org/package/chg-cli)
 [![License](https://img.shields.io/npm/l/chg-cli.svg)](https://github.com///blob/master/package.json)
 
+A Command Line tool for CHG development tasks.
+
 <!-- toc -->
+
 # Usage
+
+```
+USAGE
+  $ chg [COMMAND]
+
+COMMANDS
+  hello    Describe the command here
+  help     display help for chg
+  plugins  list installed plugins
+  project  Scaffolding and tools for creating and updating projects
+```
+
 <!-- usage -->
+
 # Commands
 <!-- commands -->
+
+## Project
+Manages the creation and updating of software projects.
+
+### Create
+Creates a project scaffolding with several options for project types.
+
+# Build
+See documentation for releasing oclif CLI's: https://oclif.io/docs/releasing
+
+# Plugins
+The `chg` CLI supports plugins!
+
+See the [oclif plugin called `plugin-plugins`](https://github.com/oclif/plugin-plugins) for support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chg-cli",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,12 @@
       "@oclif/plugin-plugins"
     ],
     "topics": {
-      "project": { "description": "Scaffolding and tools for creating and updating projects" }
+      "contracts": { "description": "Commands for creating and managing API and event contracts" },
+      "pipelines": { "description": "Commands for creating and managing pipelines" },
+      "project": { "description": "Scaffolding and tools for creating and updating projects" },
+      "services": { "description": "Commands for listing and creating services" },
+      "tools": { "description": "Commands for listing and creating tools" },
+      "workers": { "description": "Commands for listing and creating workers" }
     }
   },
   "repository": "/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chg-cli",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "John Miller",
   "bin": {
     "chg": "./bin/run"
@@ -9,7 +9,9 @@
   "dependencies": {
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
-    "@oclif/plugin-help": "^2.2.1"
+    "@oclif/plugin-help": "^2.2.1",
+    "@oclif/plugin-not-found": "^1.2.3",
+    "@oclif/plugin-plugins": "^1.7.8"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
@@ -36,8 +38,13 @@
     "commands": "./src/commands",
     "bin": "chg",
     "plugins": [
-      "@oclif/plugin-help"
-    ]
+      "@oclif/plugin-help",
+      "@oclif/plugin-not-found",
+      "@oclif/plugin-plugins"
+    ],
+    "topics": {
+      "project": { "description": "Scaffolding and tools for creating and updating projects" }
+    }
   },
   "repository": "/",
   "scripts": {

--- a/src/commands/contracts/create.js
+++ b/src/commands/contracts/create.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ContractsCreateCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ContractsCreateCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-164')
+  }
+}
+
+ContractsCreateCommand.description = `Creates a new API/event contract
+...
+Extra documentation about creating a new contract
+`
+
+ContractsCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Contract Name', required: true}),
+}
+
+module.exports = ContractsCreateCommand

--- a/src/commands/contracts/delete.js
+++ b/src/commands/contracts/delete.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ContractsDeleteCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ContractsDeleteCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-166')
+  }
+}
+
+ContractsDeleteCommand.description = `Deletes an API/event contract
+...
+Extra documentation about deleting a contract
+`
+
+ContractsDeleteCommand.flags = {
+  name: flags.string({char: 'n', description: 'Contract Name', required: true}),
+}
+
+module.exports = ContractsDeleteCommand

--- a/src/commands/contracts/list.js
+++ b/src/commands/contracts/list.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ContractsListCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ContractsListCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-165')
+  }
+}
+
+ContractsListCommand.description = `Lists available API/event contracts
+...
+Extra documentation about listing contracts
+`
+
+ContractsListCommand.flags = {
+  name: flags.string({char: 'n', description: 'Contract Name', required: true}),
+}
+
+module.exports = ContractsListCommand

--- a/src/commands/hello.js
+++ b/src/commands/hello.js
@@ -8,9 +8,9 @@ class HelloCommand extends Command {
   }
 }
 
-HelloCommand.description = `Describe the command here
-...
-Extra documentation goes here
+HelloCommand.description = `Default hello world command (for testing)
+Say hello to the world!
+Add a -n / --name parameter to say hello to a specific name
 `
 
 HelloCommand.flags = {

--- a/src/commands/pipelines/create.js
+++ b/src/commands/pipelines/create.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class PipelinesCreateCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(PipelinesCreateCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-172')
+  }
+}
+
+PipelinesCreateCommand.description = `Creates a new pipeline
+...
+Extra documentation about creating a new pipeline
+`
+
+PipelinesCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Pipeline Name', required: true}),
+}
+
+module.exports = PipelinesCreateCommand

--- a/src/commands/pipelines/delete.js
+++ b/src/commands/pipelines/delete.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class PipelinesDeleteCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(PipelinesDeleteCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-173')
+  }
+}
+
+PipelinesDeleteCommand.description = `Deletes a pipeline
+...
+Extra documentation about deleting a pipeline
+`
+
+PipelinesDeleteCommand.flags = {
+  name: flags.string({char: 'n', description: 'Pipeline Name', required: true}),
+}
+
+module.exports = PipelinesDeleteCommand

--- a/src/commands/pipelines/list.js
+++ b/src/commands/pipelines/list.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class PipelinesListCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(PipelinesListCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-174')
+  }
+}
+
+PipelinesListCommand.description = `Lists available pipelines
+...
+Extra documentation about listing pipelines
+`
+
+PipelinesListCommand.flags = {
+  name: flags.string({char: 'n', description: 'Pipeline Name', required: true}),
+}
+
+module.exports = PipelinesListCommand

--- a/src/commands/project/create.js
+++ b/src/commands/project/create.js
@@ -1,0 +1,34 @@
+const {Command, flags} = require('@oclif/command')
+
+class ProjectCreateCommand extends Command {
+  async run() {
+    const {flags} = this.parse(ProjectCreateCommand)
+    const name = flags.name
+    const language = flags.language
+    this.log(`Creating ${name} as a new ${language} project...`)
+
+    const isDocker = flags.docker
+    if (isDocker) this.log('This is a Docker project. Will include Dockerfile.')
+
+    const isK8s = flags.k8s
+    if (isK8s) this.log('This is a Kubernetes project. Will include Kubernetes scaffolding.')
+
+    const isJenkins = flags.jenkins
+    if (isJenkins) this.log('This is a Jenkins project. Will create Jenkinsfile.')
+  }
+}
+
+ProjectCreateCommand.description = `Creates a new software project
+...
+Extra documentation about creating a new software project
+`
+
+ProjectCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Project Name', required: true}),
+  language: flags.string({char: 'l', description: 'Core language for the project', options: ['node', 'java-spring-boot'], env: 'CHG_DEFAULT_LANGUAGE', required: true}),
+  docker: flags.boolean({char: 'd', description: 'Builds to Docker container?', default: false}),
+  k8s: flags.boolean({char: 'k', description: 'Add Kubernetes scaffolding?', default: false}),
+  jenkins: flags.boolean({char: 'j', description: 'Use Jenkins pipeline?', default: false}),
+}
+
+module.exports = ProjectCreateCommand

--- a/src/commands/services/create.js
+++ b/src/commands/services/create.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ServicesCreateCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ServicesCreateCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-175')
+  }
+}
+
+ServicesCreateCommand.description = `Creates a new service
+...
+Extra documentation about creating a new service
+`
+
+ServicesCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Service Name', required: true}),
+}
+
+module.exports = ServicesCreateCommand

--- a/src/commands/services/delete.js
+++ b/src/commands/services/delete.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ServicesDeleteCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ServicesDeleteCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-177')
+  }
+}
+
+ServicesDeleteCommand.description = `Deletes a service
+...
+Extra documentation about deleting a service
+`
+
+ServicesDeleteCommand.flags = {
+  name: flags.string({char: 'n', description: 'Service Name', required: true}),
+}
+
+module.exports = ServicesDeleteCommand

--- a/src/commands/services/list.js
+++ b/src/commands/services/list.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ServicesListCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ServicesListCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-176')
+  }
+}
+
+ServicesListCommand.description = `Lists available services
+...
+Extra documentation about listing services
+`
+
+ServicesListCommand.flags = {
+  name: flags.string({char: 'n', description: 'Service Name', required: true}),
+}
+
+module.exports = ServicesListCommand

--- a/src/commands/tools/create.js
+++ b/src/commands/tools/create.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ToolsCreateCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ToolsCreateCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-168')
+  }
+}
+
+ToolsCreateCommand.description = `Creates a new tool
+...
+Extra documentation about creating a new tool
+`
+
+ToolsCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Tool Name', required: true}),
+}
+
+module.exports = ToolsCreateCommand

--- a/src/commands/tools/delete.js
+++ b/src/commands/tools/delete.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ToolsDeleteCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ToolsDeleteCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-169')
+  }
+}
+
+ToolsDeleteCommand.description = `Deletes a tool
+...
+Extra documentation about deleting a tool
+`
+
+ToolsDeleteCommand.flags = {
+  name: flags.string({char: 'n', description: 'Tool Name', required: true}),
+}
+
+module.exports = ToolsDeleteCommand

--- a/src/commands/tools/list.js
+++ b/src/commands/tools/list.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class ToolsListCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(ToolsListCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-167')
+  }
+}
+
+ToolsListCommand.description = `Lists available tools
+...
+Extra documentation about listing tools
+`
+
+ToolsListCommand.flags = {
+  name: flags.string({char: 'n', description: 'Tool Name', required: true}),
+}
+
+module.exports = ToolsListCommand

--- a/src/commands/workers/create.js
+++ b/src/commands/workers/create.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class WorkersCreateCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(WorkersCreateCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-178')
+  }
+}
+
+WorkersCreateCommand.description = `Creates a new worker
+...
+Extra documentation about creating a new worker
+`
+
+WorkersCreateCommand.flags = {
+  name: flags.string({char: 'n', description: 'Worker Name', required: true}),
+}
+
+module.exports = WorkersCreateCommand

--- a/src/commands/workers/delete.js
+++ b/src/commands/workers/delete.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class WorkersDeleteCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(WorkersDeleteCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-180')
+  }
+}
+
+WorkersDeleteCommand.description = `Deletes a worker
+...
+Extra documentation about deleting a worker
+`
+
+WorkersDeleteCommand.flags = {
+  name: flags.string({char: 'n', description: 'Worker Name', required: true}),
+}
+
+module.exports = WorkersDeleteCommand

--- a/src/commands/workers/list.js
+++ b/src/commands/workers/list.js
@@ -1,0 +1,20 @@
+const {Command, flags} = require('@oclif/command')
+
+class WorkersListCommand extends Command {
+  async run() {
+    // const {flags} = this.parse(WorkersListCommand)
+    // const name = flags.name
+    this.log('Not Implemented: See Jira EA-179')
+  }
+}
+
+WorkersListCommand.description = `Lists available workers
+...
+Extra documentation about listing workers
+`
+
+WorkersListCommand.flags = {
+  name: flags.string({char: 'n', description: 'Worker Name', required: true}),
+}
+
+module.exports = WorkersListCommand


### PR DESCRIPTION
We now have the following as the top-level help for the command:

```
kgwynn@SLCL-KGWYNN8G:/mnt/c/dev/chgdev/chgcli$ (setup-project-commands) chg help
VERSION
  chg-cli/0.0.1 linux-x64 node-v8.10.0

USAGE
  $ chg [COMMAND]

COMMANDS
  contracts  Commands for creating and managing API and event contracts
  hello      Default hello world command (for testing)
  help       display help for chg
  pipelines  Commands for creating and managing pipelines
  plugins    list installed plugins
  project    Scaffolding and tools for creating and updating projects  
  services   Commands for listing and creating services
  tools      Commands for listing and creating tools
  workers    Commands for listing and creating workers
```